### PR TITLE
dns.resolveTxt a 2-d array since 0.12.0, check for actual string value

### DIFF
--- a/src/scrapers/dns.iced
+++ b/src/scrapers/dns.iced
@@ -103,7 +103,7 @@ exports.DnsScraper = class DnsScraper extends BaseScraper
     rc = if err?
       @log "| DNS error: #{err}"
       v_codes.DNS_ERROR
-    else if (proof_text_check in txt_reformat(records)) then v_codes.OK
+    else if (proof_text_check in records.map((r) -> r.toString())) then v_codes.OK
     else
       @log "| DNS failed; found TXT entries: #{JSON.stringify records}"
       v_codes.NOT_FOUND


### PR DESCRIPTION
See https://github.com/joyent/node/commit/7b72e156655afb6b998e8fb731cc65f4facb19ee

Right now DNS checks are failing, because dns.resolveTxt returns array of one element arrays (part of `keybase --debug id ojab`):
>debug: ------ Quarantined / oneshot verify -> ok! (fp=9456678949576423A6D59536DA0B5791C1D98E48)
>debug: ----- GpgKey::verify_sig ojab@dns -> null
>debug: |||| remote service desc is {"domain":"ojab.ru","protocol":"dns"}
>debug: +++++ Calling into scraper -> {"domain":"ojab.ru","protocol":"dns"}@dns -> dns://ojab.ru
>debug: ++++++ DNS check for ojab.ru
>debug: |||||| DNS failed; found TXT entries: [["v=spf1 include:_spf.google.com ~all"],["keybase-site->verification=XJLdtaNNaAQiXaVKGS8L4YE2Sx-eC7zqD4Qb6G-Fqf0"]]
>debug: ------ DNS check for ojab.ru -> 201
>debug: ++++++ DNS check for _keybase.ojab.ru
>debug: |||||| DNS failed; found TXT entries: [["keybase-site-verification=XJLdtaNNaAQiXaVKGS8L4YE2Sx-eC7zqD4Qb6G-Fqf0"]]
>debug: ------ DNS check for _keybase.ojab.ru -> 201
>debug: ----- Called scraper -> 201
>✖ admin of the DNS zone for ojab.ru (failed with code 201)
>debug: ---- ojab: checked remote dns proof

This PR fixes the issue here. Unfortunately I haven't found any contributing guide, so dont't know if JS (or other) parts should be changed as well.