### PR TITLE
PGP hash improvements

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -328,20 +328,20 @@
       }
     };
 
-    Base.prototype._v_include_pgp_hash = function() {
+    Base.prototype._v_include_pgp_details = function() {
       return false;
     };
 
-    Base.prototype._v_require_full_pgp_hash = function() {
+    Base.prototype._v_require_pgp_details = function() {
       return false;
     };
 
-    Base.prototype._v_pgp_km_to_hash = function() {
-      return this.km();
-    };
-
-    Base.prototype._v_pgp_hash_dest = function(body) {
+    Base.prototype._v_pgp_details_dest = function(body) {
       return body.key;
+    };
+
+    Base.prototype._v_pgp_km = function() {
+      return null;
     };
 
     Base.prototype.full_pgp_hash = function(opts, cb) {
@@ -359,14 +359,14 @@
                 filename: "/Users/sidney/src/keybase/proofs/src/base.iced",
                 funcname: "Base.full_pgp_hash"
               });
-              if ((_ref2 = _this._v_pgp_km_to_hash()) != null) {
+              if ((_ref2 = _this._v_pgp_km()) != null) {
                 _ref2.export_pgp_public({}, esc(__iced_deferrals.defer({
                   assign_fn: (function() {
                     return function() {
                       return key = arguments[0];
                     };
                   })(),
-                  lineno: 188
+                  lineno: 197
                 })));
               }
               __iced_deferrals._fulfill();
@@ -384,23 +384,67 @@
       })(this));
     };
 
-    Base.prototype.check_pgp_hash = function(_arg, cb) {
-      var err, hash_in, hash_real, json, ___iced_passed_deferral, __iced_deferrals, __iced_k;
+    Base.prototype._add_pgp_details = function(_arg, cb) {
+      var body, dest, err, full_hash, ___iced_passed_deferral, __iced_deferrals, __iced_k;
+      __iced_k = __iced_k_noop;
+      ___iced_passed_deferral = iced.findDeferral(arguments);
+      body = _arg.body;
+      if (!this._v_include_pgp_details()) {
+        return cb(null);
+      }
+      dest = this._v_pgp_details_dest(body);
+      (function(_this) {
+        return (function(__iced_k) {
+          __iced_deferrals = new iced.Deferrals(__iced_k, {
+            parent: ___iced_passed_deferral,
+            filename: "/Users/sidney/src/keybase/proofs/src/base.iced",
+            funcname: "Base._add_pgp_details"
+          });
+          _this.full_pgp_hash({}, __iced_deferrals.defer({
+            assign_fn: (function() {
+              return function() {
+                err = arguments[0];
+                return full_hash = arguments[1];
+              };
+            })(),
+            lineno: 207
+          }));
+          __iced_deferrals._fulfill();
+        });
+      })(this)((function(_this) {
+        return function() {
+          if (err) {
+
+          } else if (typeof full_hash !== "undefined" && full_hash !== null) {
+            dest.full_hash = full_hash;
+            if (dest.fingerprint == null) {
+              dest.fingerprint = _this._v_pgp_km().get_pgp_fingerprint().toString('hex');
+            }
+          } else if (_this._v_require_pgp_details()) {
+            err = new Error("" + (_this.proof_type_str()) + " proofs require a PGP key");
+          }
+          return cb(err);
+        };
+      })(this));
+    };
+
+    Base.prototype._check_pgp_details = function(_arg, cb) {
+      var details, err, fp_in, fp_real, hash_in, hash_real, json, kid_in, kid_real, ___iced_passed_deferral, __iced_deferrals, __iced_k;
       __iced_k = __iced_k_noop;
       ___iced_passed_deferral = iced.findDeferral(arguments);
       json = _arg.json;
       err = null;
+      details = this._v_pgp_details_dest(json.body);
       (function(_this) {
         return (function(__iced_k) {
-          var _ref2;
-          if ((hash_in = (_ref2 = _this._v_pgp_hash_dest(json.body)) != null ? _ref2.full_pgp_hash : void 0) == null) {
-            return __iced_k(_this._v_require_full_pgp_hash() ? err = new Error("This sig type requires a PGP key hash but none was provided") : void 0);
+          if (((hash_in = details != null ? details.full_hash : void 0) == null) || ((fp_in = details != null ? details.fingerprint : void 0) == null) || ((kid_in = details != null ? details.kid : void 0) == null)) {
+            return __iced_k(_this._v_require_pgp_details() ? err = new Error("" + (_this.proof_type_str()) + " proofs require a PGP key's KID, fingerprint, and full_hash but one or more were missing.") : void 0);
           } else {
             (function(__iced_k) {
               __iced_deferrals = new iced.Deferrals(__iced_k, {
                 parent: ___iced_passed_deferral,
                 filename: "/Users/sidney/src/keybase/proofs/src/base.iced",
-                funcname: "Base.check_pgp_hash"
+                funcname: "Base._check_pgp_details"
               });
               _this.full_pgp_hash({}, __iced_deferrals.defer({
                 assign_fn: (function() {
@@ -409,11 +453,11 @@
                     return hash_real = arguments[1];
                   };
                 })(),
-                lineno: 198
+                lineno: 225
               }));
               __iced_deferrals._fulfill();
             })(function() {
-              return __iced_k(err != null ? void 0 : typeof hash_real === "undefined" || hash_real === null ? err = new Error("A PGP key hash (" + hash_in + ") was in the sig body but no key was provided") : hash_in !== hash_real ? err = new Error("New PGP key's hash (" + hash_real + ") doesn't match hash in signature (" + hash_in + ")") : void 0);
+              return __iced_k(err != null ? void 0 : typeof hash_real === "undefined" || hash_real === null ? err = new Error("A PGP key hash (" + hash_in + ") was in the sig body but no key was provided") : hash_in !== hash_real ? err = new Error("New PGP key's hash (" + hash_real + ") doesn't match hash in signature (" + hash_in + ")") : fp_in !== (fp_real = _this._v_pgp_km().get_pgp_fingerprint().toString('hex')) ? err = new Error("New PGP key's fingerprint (" + fp_real + ") doesn't match fingerprint in signature (" + fp_in + ")") : kid_in !== (kid_real = _this._v_pgp_km().get_ekid().toString('hex')) ? err = new Error("New PGP key's KID (" + kid_real + ") doesn't match KID in signature (" + kid_in + ")") : void 0);
             });
           }
         });
@@ -446,7 +490,7 @@
                 filename: "/Users/sidney/src/keybase/proofs/src/base.iced",
                 funcname: "Base._v_check"
               });
-              _this.check_pgp_hash({
+              _this._check_pgp_details({
                 json: json
               }, __iced_deferrals.defer({
                 assign_fn: (function() {
@@ -454,7 +498,7 @@
                     return err = arguments[0];
                   };
                 })(),
-                lineno: 238
+                lineno: 270
               }));
               __iced_deferrals._fulfill();
             })(__iced_k);
@@ -573,27 +617,22 @@
       this._v_customize_json(ret);
       (function(_this) {
         return (function(__iced_k) {
-          if (_this._v_include_pgp_hash()) {
-            (function(__iced_k) {
-              __iced_deferrals = new iced.Deferrals(__iced_k, {
-                parent: ___iced_passed_deferral,
-                filename: "/Users/sidney/src/keybase/proofs/src/base.iced",
-                funcname: "Base.generate_json"
-              });
-              _this.full_pgp_hash({}, __iced_deferrals.defer({
-                assign_fn: (function(__slot_1) {
-                  return function() {
-                    err = arguments[0];
-                    return __slot_1.full_pgp_hash = arguments[1];
-                  };
-                })(_this._v_pgp_hash_dest(ret.body)),
-                lineno: 336
-              }));
-              __iced_deferrals._fulfill();
-            })(__iced_k);
-          } else {
-            return __iced_k();
-          }
+          __iced_deferrals = new iced.Deferrals(__iced_k, {
+            parent: ___iced_passed_deferral,
+            filename: "/Users/sidney/src/keybase/proofs/src/base.iced",
+            funcname: "Base.generate_json"
+          });
+          _this._add_pgp_details({
+            body: ret.body
+          }, __iced_deferrals.defer({
+            assign_fn: (function() {
+              return function() {
+                return err = arguments[0];
+              };
+            })(),
+            lineno: 367
+          }));
+          __iced_deferrals._fulfill();
         });
       })(this)((function(_this) {
         return function() {
@@ -620,7 +659,7 @@
             funcname: "Base.generate"
           });
           _this._v_generate({}, esc(__iced_deferrals.defer({
-            lineno: 349
+            lineno: 380
           })));
           __iced_deferrals._fulfill();
         });
@@ -638,7 +677,7 @@
                   return json = arguments[0];
                 };
               })(),
-              lineno: 350
+              lineno: 381
             })));
             __iced_deferrals._fulfill();
           })(function() {
@@ -656,7 +695,7 @@
                     return armored = arguments[0].armored;
                   };
                 })(),
-                lineno: 351
+                lineno: 382
               })));
               __iced_deferrals._fulfill();
             })(function() {
@@ -697,7 +736,7 @@
                 return json_str = arguments[2];
               };
             })(),
-            lineno: 366
+            lineno: 397
           }));
           __iced_deferrals._fulfill();
         });

--- a/lib/eldest.js
+++ b/lib/eldest.js
@@ -11,8 +11,12 @@
   exports.Eldest = Eldest = (function(_super) {
     __extends(Eldest, _super);
 
-    Eldest.prototype._v_include_pgp_hash = function() {
+    Eldest.prototype._v_include_pgp_details = function() {
       return true;
+    };
+
+    Eldest.prototype._v_pgp_km = function() {
+      return this.km;
     };
 
     function Eldest(obj) {

--- a/lib/pgp_update.js
+++ b/lib/pgp_update.js
@@ -11,15 +11,15 @@
   exports.PGPUpdate = PGPUpdate = (function(_super) {
     __extends(PGPUpdate, _super);
 
-    PGPUpdate.prototype._v_include_pgp_hash = function() {
+    PGPUpdate.prototype._v_include_pgp_details = function() {
       return true;
     };
 
-    PGPUpdate.prototype._v_require_full_pgp_hash = function() {
+    PGPUpdate.prototype._v_require_pgp_details = function() {
       return true;
     };
 
-    PGPUpdate.prototype._v_pgp_km_to_hash = function() {
+    PGPUpdate.prototype._v_pgp_km = function() {
       return this.pgpkm;
     };
 

--- a/lib/pgp_update.js
+++ b/lib/pgp_update.js
@@ -11,6 +11,10 @@
   exports.PGPUpdate = PGPUpdate = (function(_super) {
     __extends(PGPUpdate, _super);
 
+    PGPUpdate.prototype._required_sections = function() {
+      return PGPUpdate.__super__._required_sections.call(this).concat(['pgp_update']);
+    };
+
     PGPUpdate.prototype._v_include_pgp_details = function() {
       return true;
     };
@@ -19,8 +23,18 @@
       return true;
     };
 
+    PGPUpdate.prototype._v_pgp_details_dest = function(body) {
+      return body.pgp_update;
+    };
+
     PGPUpdate.prototype._v_pgp_km = function() {
       return this.pgpkm;
+    };
+
+    PGPUpdate.prototype._v_customize_json = function(ret) {
+      return ret.body.pgp_update = {
+        kid: this.pgpkm.get_ekid().toString('hex')
+      };
     };
 
     PGPUpdate.prototype._type = function() {

--- a/lib/sibkey.js
+++ b/lib/sibkey.js
@@ -37,7 +37,7 @@
       return true;
     };
 
-    Sibkey.prototype._v_include_pgp_hash = function() {
+    Sibkey.prototype._v_include_pgp_details = function() {
       return true;
     };
 

--- a/lib/subkey.js
+++ b/lib/subkey.js
@@ -58,12 +58,12 @@
       return SubkeyBase.__super__._optional_sections.call(this).concat(["device"]);
     };
 
-    SubkeyBase.prototype._v_pgp_km_to_hash = function() {
-      return this.get_new_km();
+    SubkeyBase.prototype._v_pgp_details_dest = function(body) {
+      return body[this.get_field()];
     };
 
-    SubkeyBase.prototype._v_pgp_hash_dest = function(body) {
-      return body[this.get_field()];
+    SubkeyBase.prototype._v_pgp_km = function() {
+      return this.get_new_km();
     };
 
     SubkeyBase.prototype._v_generate = function(opts, cb) {

--- a/src/eldest.iced
+++ b/src/eldest.iced
@@ -6,7 +6,8 @@
 
 exports.Eldest = class Eldest extends Base
 
-  _v_include_pgp_hash : () -> true
+  _v_include_pgp_details : () -> true
+  _v_pgp_km : () -> @km
 
   constructor : (obj) ->
     @device = obj.device

--- a/src/pgp_update.iced
+++ b/src/pgp_update.iced
@@ -5,9 +5,16 @@
 
 exports.PGPUpdate = class PGPUpdate extends Base
 
+  _required_sections : () -> super().concat ['pgp_update']
+
   _v_include_pgp_details : () -> true
   _v_require_pgp_details : () -> true
+  _v_pgp_details_dest : (body) -> body.pgp_update
   _v_pgp_km : () -> @pgpkm
+
+  _v_customize_json: (ret) ->
+    ret.body.pgp_update =
+      kid: @pgpkm.get_ekid().toString 'hex'
 
   _type : () -> constants.sig_types.pgp_update
 

--- a/src/pgp_update.iced
+++ b/src/pgp_update.iced
@@ -5,9 +5,9 @@
 
 exports.PGPUpdate = class PGPUpdate extends Base
 
-  _v_include_pgp_hash : () -> true
-  _v_require_full_pgp_hash : () -> true
-  _v_pgp_km_to_hash : () -> @pgpkm
+  _v_include_pgp_details : () -> true
+  _v_require_pgp_details : () -> true
+  _v_pgp_km : () -> @pgpkm
 
   _type : () -> constants.sig_types.pgp_update
 

--- a/src/sibkey.iced
+++ b/src/sibkey.iced
@@ -14,7 +14,7 @@ exports.Sibkey = class Sibkey extends SubkeyBase
   _type : () -> constants.sig_types.sibkey
   need_reverse_sig : () -> true
 
-  _v_include_pgp_hash : () -> true
+  _v_include_pgp_details : () -> true
   _required_sections : () -> super().concat(["sibkey"])
   _optional_sections : () -> super().concat(["revoke"])
 

--- a/src/subkey.iced
+++ b/src/subkey.iced
@@ -26,8 +26,8 @@ exports.SubkeyBase = class SubkeyBase extends Base
   need_reverse_sig : () -> false
   _optional_sections : () -> super().concat(["device"])
 
-  _v_pgp_km_to_hash : -> @get_new_km()
-  _v_pgp_hash_dest : (body) -> body[@get_field()]
+  _v_pgp_details_dest : (body) -> body[@get_field()]
+  _v_pgp_km : -> @get_new_km()
 
   _v_generate : (opts, cb) ->
     esc = make_esc cb, "_v_generate"


### PR DESCRIPTION
- Move PGP details out of the `key` stanza in `pgp_update` links, since the key may be a different signing key.

- Always include PGP keys’ fingerprints alongside `full_hash`, including in `pgp_update` links.

cc @maxtaco @oconnor663