### PR TITLE
be stricter about the structure of a Facebook post

### DIFF
--- a/lib/scrapers/facebook.js
+++ b/lib/scrapers/facebook.js
@@ -100,9 +100,10 @@
     };
 
     FacebookScraper.prototype._extract_username_and_text = function(html) {
-      var $, proof_text, user_profile_link, username, _ref, _ref1;
+      var $, post_headers_selector, proof_text, user_profile_link, username, _ref, _ref1;
       $ = this.libs.cheerio.load(html);
-      user_profile_link = $('#m_story_permalink_view h3 a').first().attr('href');
+      post_headers_selector = "#m_story_permalink_view > div:first-child > div:first-child > div:first-child h3";
+      user_profile_link = $(post_headers_selector).eq(0).find('a').first().attr('href');
       if (user_profile_link == null) {
         this.log("failed to find link to author profile");
         return [v_codes.CONTENT_MISSING, null, null];
@@ -112,7 +113,7 @@
         this.log("failed to parse author profile link: " + user_profile_link);
         return [v_codes.CONTENT_MISSING, null, null];
       }
-      proof_text = $('#m_story_permalink_view h3').eq(1).text();
+      proof_text = $(post_headers_selector).eq(1).text();
       if ((proof_text == null) || proof_text === "") {
         this.log("failed to find proof text");
         return [v_codes.CONTENT_MISSING, null, null];

--- a/src/scrapers/facebook.iced
+++ b/src/scrapers/facebook.iced
@@ -77,8 +77,9 @@ exports.FacebookScraper = class FacebookScraper extends BaseScraper
 
   _extract_username_and_text : (html) ->
     $ = @libs.cheerio.load html
+    post_headers_selector = "#m_story_permalink_view > div:first-child > div:first-child > div:first-child h3"
     # Get the username from the first link in the first header in the story.
-    user_profile_link = $('#m_story_permalink_view h3 a').first().attr('href')
+    user_profile_link = $(post_headers_selector).eq(0).find('a').first().attr('href')
     if not user_profile_link?
       @log "failed to find link to author profile"
       return [v_codes.CONTENT_MISSING, null, null]
@@ -88,7 +89,7 @@ exports.FacebookScraper = class FacebookScraper extends BaseScraper
       return [v_codes.CONTENT_MISSING, null, null]
 
     # Get the proof text from the contents of the second header in the story.
-    proof_text = $('#m_story_permalink_view h3').eq(1).text()
+    proof_text = $(post_headers_selector).eq(1).text()
     if not proof_text? or proof_text == ""
       @log "failed to find proof text"
       return [v_codes.CONTENT_MISSING, null, null]


### PR DESCRIPTION
Other users' comments can also include \<h3> and \<table> tags. Currently
the best way to distinguish the poster's text is to assert that the divs
we're looking at are the first ones in the post. All of this might break
if Facebook changes its layout, but hopefully we can be strict at first
and loosen up later if need be.

r? @maxtaco 