### PR TITLE
fix incorrect call to replace

### DIFF
--- a/lib/scrapers/facebook.js
+++ b/lib/scrapers/facebook.js
@@ -141,7 +141,7 @@
   })(BaseScraper);
 
   username_normalize = function(username) {
-    return username.toLowerCase().replace(/\./g);
+    return username.toLowerCase().replace(/\./g, '');
   };
 
   usernames_equal = function(user1, user2) {

--- a/src/scrapers/facebook.iced
+++ b/src/scrapers/facebook.iced
@@ -113,7 +113,7 @@ exports.FacebookScraper = class FacebookScraper extends BaseScraper
 
 username_normalize = (username) ->
   # Lowercase the letters and remove all dots.
-  username.toLowerCase().replace(/\./g)
+  username.toLowerCase().replace(/\./g, '')
 
 usernames_equal = (user1, user2) ->
   username_normalize(user1) == username_normalize(user2)


### PR DESCRIPTION
The lack of a second argument was replacing '.' with 'undefined'. Bad
testing on my part.

r? @maxtaco @cjb 

After landing, we'll need to revendor this in kbweb.