### PR TITLE
[JS] actually parse Facebook desktop markup, and unescape '--' properly

### DIFF
--- a/lib/scrapers/facebook.js
+++ b/lib/scrapers/facebook.js
@@ -66,7 +66,7 @@
     };
 
     FacebookScraper.prototype.check_status = function(_arg, cb) {
-      var api_url, desktop_url, err, proof_text_check, proof_text_regex, raw, rc, regex_escaped_proof_text, remote_id, username, ___iced_passed_deferral, __iced_deferrals, __iced_k;
+      var api_url, desktop_url, err, first_code_comment, link_text, page$, proof$, proof_text_check, raw, rc, remote_id, unescaped_comment, username, ___iced_passed_deferral, __iced_deferrals, __iced_k;
       __iced_k = __iced_k_noop;
       ___iced_passed_deferral = iced.findDeferral(arguments);
       username = _arg.username, api_url = _arg.api_url, proof_text_check = _arg.proof_text_check, remote_id = _arg.remote_id;
@@ -95,19 +95,27 @@
                 return raw = arguments[2];
               };
             })(),
-            lineno: 78
+            lineno: 81
           }));
           __iced_deferrals._fulfill();
         });
       })(this)((function(_this) {
         return function() {
+          var _ref;
           if ((typeof err !== "undefined" && err !== null) || rc !== v_codes.OK) {
             return cb(err, rc);
           }
-          regex_escaped_proof_text = proof_text_check.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&");
-          proof_text_regex = new RegExp("<a[^>]*>\\s*" + regex_escaped_proof_text + "\\s*</a[^>]*>");
-          if (raw.match(proof_text_regex) == null) {
-            _this.log("failed to find proof text '" + proof_text_check + "' in Facebook response");
+          page$ = _this.libs.cheerio.load(raw);
+          first_code_comment = (_ref = page$('code').eq(0).contents().toArray()[0]) != null ? _ref.data : void 0;
+          if (first_code_comment == null) {
+            _this.log("failed to find proof markup comment in Facebook response");
+            return cb(null, v_codes.TEXT_NOT_FOUND);
+          }
+          unescaped_comment = first_code_comment.split("-\\-\\").join("--").split("\\\\").join("\\");
+          proof$ = _this.libs.cheerio.load(unescaped_comment);
+          link_text = proof$('div.userContent+div a').text();
+          if (link_text !== proof_text_check) {
+            _this.log("failed to find attachment title '" + proof_text_check + "' in Facebook post " + desktop_url);
             return cb(null, v_codes.TEXT_NOT_FOUND);
           }
           return cb(null, v_codes.OK);

--- a/lib/scrapers/facebook.js
+++ b/lib/scrapers/facebook.js
@@ -114,7 +114,7 @@
           unescaped_comment = first_code_comment.split("-\\-\\").join("--").split("\\\\").join("\\");
           proof$ = _this.libs.cheerio.load(unescaped_comment);
           link_text = proof$('div.userContent+div a').text();
-          if (link_text !== proof_text_check) {
+          if (link_text.trim() !== proof_text_check.trim()) {
             _this.log("failed to find attachment title '" + proof_text_check + "' in Facebook post " + desktop_url);
             return cb(null, v_codes.TEXT_NOT_FOUND);
           }

--- a/src/scrapers/facebook.iced
+++ b/src/scrapers/facebook.iced
@@ -101,7 +101,7 @@ exports.FacebookScraper = class FacebookScraper extends BaseScraper
     # 'userContet' div".
     link_text = proof$('div.userContent+div a').text()
 
-    if link_text != proof_text_check
+    if link_text.trim() != proof_text_check.trim()
       @log "failed to find attachment title '#{proof_text_check}' in Facebook post #{desktop_url}"
       return cb null, v_codes.TEXT_NOT_FOUND
 


### PR DESCRIPTION
Previously we were doing a plain text search for proof text in the
desktop page. That was a little sketchy structurally, but it also ran
into a correctness issue: comments can't contain a "--" character, and
if proofs contained that pair (as it does in a random 1% of our base64
medium sig IDs), we weren't matching it properly.

The simplest possible thing would be to just replace "--" with "-\-\"
before we match. That would *probably* work. However there's a lot of
basic HTML escaping (like &amp;) that's allowed in this context, so
comparing escaped strings char-by-char is an escaping-flexibility
landmine just waiting to explode and break us again.

Instead of looking for escaped text in the page, we should be
*unescaping* text and comparing it to our known string. To do that right
we need to properly structurally parse the page instead of blindly
string searching it. That requires a second parse in the middle, which
is a little complicated, but it works, and it feels much safer in the
long term. (Way less likely to get confused by other text that could
sneak into the page.)

r? @maxtaco @mlsteele 