### PR TITLE
strictly select the 2nd (eq(1)) link in Facebook post HTML

### DIFF
--- a/lib/scrapers/facebook.js
+++ b/lib/scrapers/facebook.js
@@ -113,7 +113,7 @@
           }
           unescaped_comment = first_code_comment.split("-\\-\\").join("--").split("\\\\").join("\\");
           proof$ = _this.libs.cheerio.load(unescaped_comment);
-          link_text = proof$('div.userContent+div a').text();
+          link_text = proof$('div.userContent+div a').eq(1).text();
           if (link_text.trim() !== proof_text_check.trim()) {
             _this.log("failed to find attachment title '" + proof_text_check + "' in Facebook post " + desktop_url);
             return cb(null, v_codes.TEXT_NOT_FOUND);

--- a/src/scrapers/facebook.iced
+++ b/src/scrapers/facebook.iced
@@ -99,7 +99,7 @@ exports.FacebookScraper = class FacebookScraper extends BaseScraper
     # This is the selector for the post attachment link. It's the "text of the
     # first <a> tag inside the div that's the immediate *sibling* of the
     # 'userContet' div".
-    link_text = proof$('div.userContent+div a').text()
+    link_text = proof$('div.userContent+div a').eq(1).text()
 
     if link_text.trim() != proof_text_check.trim()
       @log "failed to find attachment title '#{proof_text_check}' in Facebook post #{desktop_url}"


### PR DESCRIPTION
Previously we concatenated text from multiple links, because we believed
that all but one of them had to be blank.
https://github.com/keybase/keybase-issues/issues/2768 shows that we were
wrong!

r? @maxtaco @mlsteele 

I tested with the following script run in the root of kbweb, doesn't work before this change, but works after:

```coffeescript
cheerio = require 'cheerio'
request = require 'request'
proofs = require 'keybase-proofs'

log =
  debug: console.log

libs = {cheerio, request, log}

fbscraper = new proofs.FacebookScraper {libs}

username = "olegatro"
api_url = "https://www.facebook.com/olegatro/posts/649426738562818"
proof_text_check = "Verifying myself: I am olegatro on Keybase.io. luYeEGAM-OFQ6aEnM-wDmCIp9F6L-Q3SeTBtoTIrO0c"

await fbscraper.check_status {username, api_url, proof_text_check}, defer err, status

console.log(err)
console.log(status)
```