### PR TITLE
specify seq_type as optional 6th field in a sigchain outerlink

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -337,7 +337,7 @@
         });
       })(this)((function(_this) {
         return function() {
-          err = (a = outer.type) !== (b = _this.base._type_v2(has_revoke(inner_obj.body))) ? new Error("Type mismatch: " + a + " != " + b) : (a = outer.version) !== (b = constants.versions.sig_v2) ? new Error("Bad version: " + a + " != " + b) : (a = outer.version) !== (b = inner_obj.body.version) ? new Error("Version mismatch: " + a + " != " + b) : !bufeq_secure((a = outer.hash), (b = hash_sig(inner_buf))) ? new Error("hash mismatch: " + (a != null ? a.toString('hex') : void 0) + " != " + (b != null ? b.toString('hex') : void 0)) : (a = outer.seqno) !== (b = inner_obj.seqno) ? new Error("wrong seqno: " + a + " != " + b) : !compare_hash_buf_to_str((a = outer.prev), (b = inner_obj.prev)) ? new Error("wrong prev: " + (a != null ? a.toString('hex') : void 0) + " != " + b) : null;
+          err = (a = outer.type) !== (b = _this.base._type_v2(has_revoke(inner_obj.body))) ? new Error("Type mismatch: " + a + " != " + b) : (a = outer.version) !== (b = constants.versions.sig_v2) ? new Error("Bad version: " + a + " != " + b) : (a = outer.version) !== (b = inner_obj.body.version) ? new Error("Version mismatch: " + a + " != " + b) : !bufeq_secure((a = outer.hash), (b = hash_sig(inner_buf))) ? new Error("hash mismatch: " + (a != null ? a.toString('hex') : void 0) + " != " + (b != null ? b.toString('hex') : void 0)) : (a = outer.seqno) !== (b = inner_obj.seqno) ? new Error("wrong seqno: " + a + " != " + b) : !compare_hash_buf_to_str((a = outer.prev), (b = inner_obj.prev)) ? new Error("wrong prev: " + (a != null ? a.toString('hex') : void 0) + " != " + b) : (a = outer.seq_type) !== (b = inner_obj.seq_type || constants.seq_types.PUBLIC) ? new Error("wrong seq type: " + a + " != " + b) : null;
           return cb(err, outer);
         };
       })(this));
@@ -417,7 +417,7 @@
                 return body = arguments[2];
               };
             })(),
-            lineno: 182
+            lineno: 184
           }));
           __iced_deferrals._fulfill();
         });
@@ -437,7 +437,7 @@
                       return err = arguments[0];
                     };
                   })(),
-                  lineno: 184
+                  lineno: 186
                 }));
                 __iced_deferrals._fulfill();
               })(__iced_k);
@@ -496,7 +496,7 @@
                             return err = arguments[0];
                           };
                         })(),
-                        lineno: 208
+                        lineno: 210
                       }));
                       __iced_deferrals._fulfill();
                     })(__iced_k);
@@ -620,7 +620,7 @@
                       return __slot_1._full_pgp_hash = arguments[0];
                     };
                   })(_this),
-                  lineno: 285
+                  lineno: 287
                 })));
               }
               __iced_deferrals._fulfill();
@@ -659,7 +659,7 @@
                 return full_hash = arguments[1];
               };
             })(),
-            lineno: 294
+            lineno: 296
           }));
           __iced_deferrals._fulfill();
         });
@@ -705,7 +705,7 @@
                     return hash_real = arguments[1];
                   };
                 })(),
-                lineno: 312
+                lineno: 314
               }));
               __iced_deferrals._fulfill();
             })(function() {
@@ -798,7 +798,7 @@
                     return err = arguments[0];
                   };
                 })(),
-                lineno: 388
+                lineno: 390
               }));
               __iced_deferrals._fulfill();
             })(__iced_k);
@@ -932,7 +932,7 @@
                 return err = arguments[0];
               };
             })(),
-            lineno: 490
+            lineno: 492
           }));
           __iced_deferrals._fulfill();
         });
@@ -964,7 +964,7 @@
             funcname: "Base.generate"
           });
           _this._v_generate(opts, esc(__iced_deferrals.defer({
-            lineno: 504
+            lineno: 506
           })));
           __iced_deferrals._fulfill();
         });
@@ -983,7 +983,7 @@
                   return json_obj = arguments[1];
                 };
               })(),
-              lineno: 505
+              lineno: 507
             })));
             __iced_deferrals._fulfill();
           })(function() {
@@ -1005,7 +1005,7 @@
                     return armored = arguments[0].armored;
                   };
                 })(),
-                lineno: 507
+                lineno: 509
               })));
               __iced_deferrals._fulfill();
             })(function() {
@@ -1044,7 +1044,7 @@
             funcname: "Base.generate_v2"
           });
           _this._v_generate(opts, esc(__iced_deferrals.defer({
-            lineno: 518
+            lineno: 520
           })));
           __iced_deferrals._fulfill();
         });
@@ -1063,7 +1063,7 @@
                   return o = arguments[1];
                 };
               })(),
-              lineno: 519
+              lineno: 521
             })));
             __iced_deferrals._fulfill();
           })(function() {
@@ -1085,7 +1085,7 @@
                     return outer = arguments[0];
                   };
                 })(),
-                lineno: 521
+                lineno: 523
               })));
               __iced_deferrals._fulfill();
             })(function() {
@@ -1103,7 +1103,7 @@
                       return armored = arguments[0].armored;
                     };
                   })(),
-                  lineno: 522
+                  lineno: 524
                 })));
                 __iced_deferrals._fulfill();
               })(function() {
@@ -1157,7 +1157,8 @@
           type: this._type_v2(),
           seqno: inner.obj.seqno || 0,
           prev: prev_buf,
-          hash: hash_sig(new Buffer(inner.str, 'utf8'))
+          hash: hash_sig(new Buffer(inner.str, 'utf8')),
+          seq_type: inner.obj.seq_type || constants.seq_types.SEMIPRIVATE
         });
         ret = unpacked.pack();
       }
@@ -1184,7 +1185,7 @@
                 return json_str = arguments[2];
               };
             })(),
-            lineno: 570
+            lineno: 573
           }));
           __iced_deferrals._fulfill();
         });
@@ -1230,7 +1231,7 @@
                 return json_str = arguments[3];
               };
             })(),
-            lineno: 591
+            lineno: 594
           }));
           __iced_deferrals._fulfill();
         });
@@ -1321,7 +1322,8 @@
 
   OuterLink = (function() {
     function OuterLink(_arg) {
-      this.version = _arg.version, this.seqno = _arg.seqno, this.prev = _arg.prev, this.hash = _arg.hash, this.type = _arg.type;
+      this.version = _arg.version, this.seqno = _arg.seqno, this.prev = _arg.prev, this.hash = _arg.hash, this.type = _arg.type, this.seq_type = _arg.seq_type;
+      this.seq_type || (this.seq_type = constants.seq_types.SEMIPRIVATE);
     }
 
     OuterLink.parse = function(_arg, cb) {
@@ -1345,22 +1347,24 @@
                 return arr = arguments[0];
               };
             })(),
-            lineno: 660
+            lineno: 664
           })));
           __iced_deferrals._fulfill();
         });
       })(this)((function(_this) {
         return function() {
+          var _ref2;
           err = ret = null;
-          if (arr.length !== 5) {
-            err = new Error("expected 5 fields; got " + arr.length);
+          if ((_ref2 = arr.length) !== 5 && _ref2 !== 6) {
+            err = new Error("expected 5 or 6 fields; got " + arr.length);
           } else {
             ret = new OuterLink({
               version: arr[0],
               seqno: arr[1],
               prev: arr[2],
               hash: arr[3],
-              type: arr[4]
+              type: arr[4],
+              seq_type: arr[5]
             });
           }
           return cb(err, ret);
@@ -1369,7 +1373,7 @@
     };
 
     OuterLink.prototype.pack = function() {
-      return purepack.pack([this.version, this.seqno, this.prev, this.hash, this.type]);
+      return purepack.pack([this.version, this.seqno, this.prev, this.hash, this.type, this.seq_type]);
     };
 
     OuterLink.prototype.outer_link_hash = function() {

--- a/test/files/util.iced
+++ b/test/files/util.iced
@@ -1,5 +1,6 @@
 
 {prng} = require 'crypto'
+{constants} = require '../..'
 
 exports.new_uid = new_uid = () -> prng(16).toString('hex')
 exports.new_username = new_username = () -> "u_" + prng(5).toString('hex')
@@ -15,4 +16,5 @@ exports.new_sig_arg = new_sig_arg = ({km}) ->
     host : "keybase.io"
     sig_eng : km.make_sig_eng()
     seqno : 0
+    seq_type : constants.seq_types.PUBLIC
     prev : null


### PR DESCRIPTION
- by default, sigchain v2 links are SEMIPRIVATE, if unspecified
- by default, sigchain v1 links are PUBLIC, if unspecified
- this is due to a bug that's now permanent, but we can workaround it with the above hack