### PR TITLE
Reddit ignore post body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.34 (2018-04-24)
+
+- Ignore post body in reddit proofs
+
 ## 2.1.33 (2018-03-26)
 
 - Rename wallet -> wallet.stellar

--- a/lib/scrapers/reddit.js
+++ b/lib/scrapers/reddit.js
@@ -60,7 +60,7 @@
         return (function(__iced_k) {
           __iced_deferrals = new iced.Deferrals(__iced_k, {
             parent: ___iced_passed_deferral,
-            filename: "/Users/max/src/keybase/proofs/src/scrapers/reddit.iced",
+            filename: "/Users/miles/go/src/github.com/keybase/proofs/src/scrapers/reddit.iced",
             funcname: "RedditScraper.hunt2"
           });
           _this._get_url_body({
@@ -164,11 +164,7 @@
       } else if (post.title.indexOf(med_id) < 0) {
         return v_codes.TITLE_NOT_FOUND;
       } else {
-        if (this._find_sig_in_raw(proof_text_check, post.selftext)) {
-          return v_codes.OK;
-        } else {
-          return v_codes.TEXT_NOT_FOUND;
-        }
+        return v_codes.OK;
       }
     };
 
@@ -181,7 +177,7 @@
         return (function(__iced_k) {
           __iced_deferrals = new iced.Deferrals(__iced_k, {
             parent: ___iced_passed_deferral,
-            filename: "/Users/max/src/keybase/proofs/src/scrapers/reddit.iced",
+            filename: "/Users/miles/go/src/github.com/keybase/proofs/src/scrapers/reddit.iced",
             funcname: "RedditScraper.check_status"
           });
           _this._get_url_body({
@@ -198,7 +194,7 @@
                 return json = arguments[2];
               };
             })(),
-            lineno: 119
+            lineno: 118
           }));
           __iced_deferrals._fulfill();
         });

--- a/src/scrapers/reddit.iced
+++ b/src/scrapers/reddit.iced
@@ -107,8 +107,7 @@ exports.RedditScraper = class RedditScraper extends BaseScraper
     else if (post.title.indexOf(med_id) < 0)
       v_codes.TITLE_NOT_FOUND
     else
-      if @_find_sig_in_raw(proof_text_check, post.selftext) then v_codes.OK
-      else v_codes.TEXT_NOT_FOUND
+      v_codes.OK
 
   # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Reddit's redesign has an issue where the when a user posts using the prefilled form and does _not_ click on the body, then the body is dropped when the form is submitted.

To work around this we can just stop checking the bodies. And users will be allowed to post anything in the body, empty or not, and have their proof check succeed.

For example that's what happened to this proof: https://www.reddit.com/r/KeybaseProofs/comments/8enb0o/my_keybase_proof_redditpharrisee_keybasepharrisee/