### PR TITLE
Surya/nil/hprev hashes are buffers

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -1232,7 +1232,7 @@
     Base.prototype.hex_to_buf = function(_arg, cb) {
       var buf, e, err, hex_str, n;
       hex_str = _arg.hex_str, n = _arg.n;
-      buf = null;
+      err = buf = null;
       if (hex_str == null) {
         return cb(null, buf);
       }

--- a/lib/base.js
+++ b/lib/base.js
@@ -1232,8 +1232,9 @@
     Base.prototype.hex_to_buf = function(_arg, cb) {
       var buf, e, err, hex_str, n;
       hex_str = _arg.hex_str, n = _arg.n;
+      buf = null;
       if (hex_str == null) {
-        return cb(null, null);
+        return cb(null, buf);
       }
       n || (n = 32);
       try {
@@ -1245,15 +1246,16 @@
       if ((err == null) && buf.length !== n) {
         err = new Error("bad hash length: " + buf.length);
       }
-      return cb(null, buf);
+      return cb(err, buf);
     };
 
     Base.prototype.generate_outer = function(_arg, cb) {
-      var err, hprev_hash_buf, hprev_info, inner, prev_buf, ret, unpacked, x, ___iced_passed_deferral, __iced_deferrals, __iced_k;
+      var esc, hprev_hash_buf, hprev_info, inner, prev_buf, ret, unpacked, x, ___iced_passed_deferral, __iced_deferrals, __iced_k;
       __iced_k = __iced_k_noop;
       ___iced_passed_deferral = iced.findDeferral(arguments);
       inner = _arg.inner;
-      ret = prev_buf = err = unpacked = null;
+      esc = make_esc(cb, "generate_outer");
+      ret = prev_buf = unpacked = null;
       (function(_this) {
         return (function(__iced_k) {
           var _ref2;
@@ -1263,47 +1265,40 @@
             funcname: "Base.generate_outer"
           });
           _this.hex_to_buf({
-            hex_str: inner != null ? (_ref2 = inner.obj) != null ? _ref2.prev : void 0 : void 0
-          }, __iced_deferrals.defer({
+            hex_str: (_ref2 = inner.obj) != null ? _ref2.prev : void 0
+          }, esc(__iced_deferrals.defer({
             assign_fn: (function() {
               return function() {
-                err = arguments[0];
-                return prev_buf = arguments[1];
+                return prev_buf = arguments[0];
               };
             })(),
-            lineno: 624
-          }));
+            lineno: 625
+          })));
           __iced_deferrals._fulfill();
         });
       })(this)((function(_this) {
         return function() {
-          if (err != null) {
-            return cb(err, ret, unpacked);
-          }
           (function(__iced_k) {
-            var _ref2;
+            var _ref2, _ref3;
             __iced_deferrals = new iced.Deferrals(__iced_k, {
               parent: ___iced_passed_deferral,
               filename: "/home/me/code/proofs/src/base.iced",
               funcname: "Base.generate_outer"
             });
             _this.hex_to_buf({
-              hex_str: (_ref2 = inner.obj.hprev_info) != null ? _ref2.hash : void 0
-            }, __iced_deferrals.defer({
+              hex_str: (_ref2 = inner.obj) != null ? (_ref3 = _ref2.hprev_info) != null ? _ref3.hash : void 0 : void 0
+            }, esc(__iced_deferrals.defer({
               assign_fn: (function() {
                 return function() {
-                  err = arguments[0];
-                  return hprev_hash_buf = arguments[1];
+                  return hprev_hash_buf = arguments[0];
                 };
               })(),
               lineno: 626
-            }));
+            })));
             __iced_deferrals._fulfill();
           })(function() {
-            if (err != null) {
-              return cb(err, ret, unpacked);
-            }
-            if (inner.obj.hprev_info != null) {
+            var _ref2;
+            if (((_ref2 = inner.obj) != null ? _ref2.hprev_info : void 0) != null) {
               hprev_info = {
                 seqno: inner.obj.hprev_info.seqno,
                 hash: hprev_hash_buf
@@ -1322,7 +1317,7 @@
               hprev_info: hprev_info
             });
             ret = unpacked.pack();
-            return cb(err, ret, unpacked);
+            return cb(null, ret, unpacked);
           });
         };
       })(this));
@@ -1348,7 +1343,7 @@
                 return json_str = arguments[2];
               };
             })(),
-            lineno: 663
+            lineno: 662
           }));
           __iced_deferrals._fulfill();
         });
@@ -1394,7 +1389,7 @@
                 return json_str = arguments[3];
               };
             })(),
-            lineno: 684
+            lineno: 683
           }));
           __iced_deferrals._fulfill();
         });
@@ -1509,7 +1504,7 @@
                 return arr = arguments[0];
               };
             })(),
-            lineno: 759
+            lineno: 758
           })));
           __iced_deferrals._fulfill();
         });

--- a/lib/base.js
+++ b/lib/base.js
@@ -398,7 +398,7 @@
       })(this)((function(_this) {
         return function() {
           var _ref2, _ref3, _ref4, _ref5;
-          err = (a = outer.type) !== (b = _this.base._type_v2(has_revoke(inner_obj.body))) ? new Error("Type mismatch: " + (errsan(a)) + " != " + (errsan(b))) : (a = outer.version) !== (b = constants.versions.sig_v2) ? new Error("Bad version: " + (errsan(a)) + " != " + (errsan(b))) : (a = outer.version) !== (b = inner_obj.body.version) ? new Error("Version mismatch: " + (errsan(a)) + " != " + (errsan(b))) : !bufeq_secure((a = outer.hash), (b = hash_sig(inner_buf))) ? new Error("hash mismatch: " + (a != null ? a.toString('hex') : void 0) + " != " + (b != null ? b.toString('hex') : void 0)) : (a = outer.seqno) !== (b = inner_obj.seqno) ? (err = new errors.WrongSeqnoError("wrong seqno: " + (errsan(a)) + " != " + (errsan(b))), err.seqno = b, err) : !compare_hash_buf_to_str((a = outer.prev), (b = inner_obj.prev)) ? new Error("wrong prev: " + (a != null ? a.toString('hex') : void 0) + " != " + (errsan(b))) : (a = outer.get_seq_type()) !== (b = inner_obj.seq_type || constants.seq_types.PUBLIC) ? new Error("wrong seq type: " + (errsan(a)) + " != " + (errsan(b))) : (a = outer.get_ignore_if_unsupported()) !== (b = inner_obj.ignore_if_unsupported || false) ? new Error("wrong ignore_if_unsupported value: " + (errsan(a)) + " != " + (errsan(b))) : (a = (_ref2 = outer.get_hprev_info()) != null ? _ref2.seqno : void 0) !== (b = ((_ref3 = inner_obj.hprev_info) != null ? _ref3.seqno : void 0)) ? new Error("wrong hprev seqno: " + (errsan(a)) + " != " + (errsan(b))) : (a = (_ref4 = outer.get_hprev_info()) != null ? _ref4.hash : void 0) !== (b = ((_ref5 = inner_obj.hprev_info) != null ? _ref5.hash : void 0)) ? new Error("wrong hprev hash value: " + (errsan(a)) + " != " + (errsan(b))) : null;
+          err = (a = outer.type) !== (b = _this.base._type_v2(has_revoke(inner_obj.body))) ? new Error("Type mismatch: " + (errsan(a)) + " != " + (errsan(b))) : (a = outer.version) !== (b = constants.versions.sig_v2) ? new Error("Bad version: " + (errsan(a)) + " != " + (errsan(b))) : (a = outer.version) !== (b = inner_obj.body.version) ? new Error("Version mismatch: " + (errsan(a)) + " != " + (errsan(b))) : !bufeq_secure((a = outer.hash), (b = hash_sig(inner_buf))) ? new Error("hash mismatch: " + (a != null ? a.toString('hex') : void 0) + " != " + (b != null ? b.toString('hex') : void 0)) : (a = outer.seqno) !== (b = inner_obj.seqno) ? (err = new errors.WrongSeqnoError("wrong seqno: " + (errsan(a)) + " != " + (errsan(b))), err.seqno = b, err) : !compare_hash_buf_to_str((a = outer.prev), (b = inner_obj.prev)) ? new Error("wrong prev: " + (a != null ? a.toString('hex') : void 0) + " != " + (errsan(b))) : (a = outer.get_seq_type()) !== (b = inner_obj.seq_type || constants.seq_types.PUBLIC) ? new Error("wrong seq type: " + (errsan(a)) + " != " + (errsan(b))) : (a = outer.get_ignore_if_unsupported()) !== (b = inner_obj.ignore_if_unsupported || false) ? new Error("wrong ignore_if_unsupported value: " + (errsan(a)) + " != " + (errsan(b))) : (a = (_ref2 = outer.get_hprev_info()) != null ? _ref2.seqno : void 0) !== (b = ((_ref3 = inner_obj.hprev_info) != null ? _ref3.seqno : void 0)) ? new Error("wrong hprev seqno: " + (errsan(a)) + " != " + (errsan(b))) : !compare_hash_buf_to_str((a = (_ref4 = outer.get_hprev_info()) != null ? _ref4.hash : void 0), (b = ((_ref5 = inner_obj.hprev_info) != null ? _ref5.hash : void 0))) ? new Error("wrong hprev hash value: " + (a != null ? a.toString('hex') : void 0) + " != " + (errsan(b))) : null;
           return cb(err, outer);
         };
       })(this));
@@ -1229,35 +1229,103 @@
       }
     };
 
+    Base.prototype.hex_to_buf = function(_arg, cb) {
+      var buf, e, err, hex_str, n;
+      hex_str = _arg.hex_str, n = _arg.n;
+      if (hex_str == null) {
+        return cb(null, null);
+      }
+      n || (n = 32);
+      try {
+        buf = new Buffer(hex_str, 'hex');
+      } catch (_error) {
+        e = _error;
+        err = new Error("failed to read " + (errsan(hex_str)) + " as a hex string");
+      }
+      if ((err == null) && buf.length !== n) {
+        err = new Error("bad hash length: " + buf.length);
+      }
+      return cb(null, buf);
+    };
+
     Base.prototype.generate_outer = function(_arg, cb) {
-      var e, err, inner, p, prev_buf, ret, unpacked, x;
+      var err, hprev_hash_buf, hprev_info, inner, prev_buf, ret, unpacked, x, ___iced_passed_deferral, __iced_deferrals, __iced_k;
+      __iced_k = __iced_k_noop;
+      ___iced_passed_deferral = iced.findDeferral(arguments);
       inner = _arg.inner;
       ret = prev_buf = err = unpacked = null;
-      if ((p = inner.obj.prev) != null) {
-        try {
-          prev_buf = new Buffer(p, 'hex');
-        } catch (_error) {
-          e = _error;
-          err = new Error("failed to read " + (errsan(p)) + " as a hex string");
-        }
-        if ((err == null) && prev_buf.length !== 32) {
-          err = new Error("bad hash length: " + prev_buf.length);
-        }
-      }
-      if (err == null) {
-        unpacked = new OuterLink({
-          version: constants.versions.sig_v2,
-          type: this._type_v2(),
-          seqno: inner.obj.seqno || 0,
-          prev: prev_buf,
-          hash: hash_sig(new Buffer(inner.str, 'utf8')),
-          seq_type: (x = inner.obj.seq_type_for_testing) != null ? x : inner.obj.seq_type || constants.seq_types.SEMIPRIVATE,
-          ignore_if_unsupported: (x = inner.obj.ignore_if_unsupported_for_testing) != null ? x : !!(inner.obj.ignore_if_unsupported || false),
-          hprev_info: inner.obj.hprev_info || null
+      (function(_this) {
+        return (function(__iced_k) {
+          var _ref2;
+          __iced_deferrals = new iced.Deferrals(__iced_k, {
+            parent: ___iced_passed_deferral,
+            filename: "/home/me/code/proofs/src/base.iced",
+            funcname: "Base.generate_outer"
+          });
+          _this.hex_to_buf({
+            hex_str: inner != null ? (_ref2 = inner.obj) != null ? _ref2.prev : void 0 : void 0
+          }, __iced_deferrals.defer({
+            assign_fn: (function() {
+              return function() {
+                err = arguments[0];
+                return prev_buf = arguments[1];
+              };
+            })(),
+            lineno: 624
+          }));
+          __iced_deferrals._fulfill();
         });
-        ret = unpacked.pack();
-      }
-      return cb(err, ret, unpacked);
+      })(this)((function(_this) {
+        return function() {
+          if (err != null) {
+            return cb(err, ret, unpacked);
+          }
+          (function(__iced_k) {
+            var _ref2;
+            __iced_deferrals = new iced.Deferrals(__iced_k, {
+              parent: ___iced_passed_deferral,
+              filename: "/home/me/code/proofs/src/base.iced",
+              funcname: "Base.generate_outer"
+            });
+            _this.hex_to_buf({
+              hex_str: (_ref2 = inner.obj.hprev_info) != null ? _ref2.hash : void 0
+            }, __iced_deferrals.defer({
+              assign_fn: (function() {
+                return function() {
+                  err = arguments[0];
+                  return hprev_hash_buf = arguments[1];
+                };
+              })(),
+              lineno: 626
+            }));
+            __iced_deferrals._fulfill();
+          })(function() {
+            if (err != null) {
+              return cb(err, ret, unpacked);
+            }
+            if (inner.obj.hprev_info != null) {
+              hprev_info = {
+                seqno: inner.obj.hprev_info.seqno,
+                hash: hprev_hash_buf
+              };
+            } else {
+              hprev_info = null;
+            }
+            unpacked = new OuterLink({
+              version: constants.versions.sig_v2,
+              type: _this._type_v2(),
+              seqno: inner.obj.seqno || 0,
+              prev: prev_buf,
+              hash: hash_sig(new Buffer(inner.str, 'utf8')),
+              seq_type: (x = inner.obj.seq_type_for_testing) != null ? x : inner.obj.seq_type || constants.seq_types.SEMIPRIVATE,
+              ignore_if_unsupported: (x = inner.obj.ignore_if_unsupported_for_testing) != null ? x : !!(inner.obj.ignore_if_unsupported || false),
+              hprev_info: hprev_info
+            });
+            ret = unpacked.pack();
+            return cb(err, ret, unpacked);
+          });
+        };
+      })(this));
     };
 
     Base.prototype.verify = function(obj, cb) {
@@ -1280,7 +1348,7 @@
                 return json_str = arguments[2];
               };
             })(),
-            lineno: 641
+            lineno: 663
           }));
           __iced_deferrals._fulfill();
         });
@@ -1326,7 +1394,7 @@
                 return json_str = arguments[3];
               };
             })(),
-            lineno: 662
+            lineno: 684
           }));
           __iced_deferrals._fulfill();
         });
@@ -1441,7 +1509,7 @@
                 return arr = arguments[0];
               };
             })(),
-            lineno: 737
+            lineno: 759
           })));
           __iced_deferrals._fulfill();
         });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "keybase-proofs",
-  "version": "2.1.43",
+  "version": "2.1.46",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -14,11 +14,11 @@
       "resolved": "https://registry.npmjs.org/bitcoyne/-/bitcoyne-1.0.4.tgz",
       "integrity": "sha1-AstFFEizfByJ37LDMJWkYZUjlng=",
       "requires": {
-        "base32.js": "0.1.0",
-        "iced-error": "0.0.9",
-        "iced-runtime": "1.0.3",
-        "kbpgp": "2.0.77",
-        "pgp-utils": "0.0.30"
+        "base32.js": "^0.1.0",
+        "iced-error": "^0.0.9",
+        "iced-runtime": "^1.0.2",
+        "kbpgp": "^2.0.0",
+        "pgp-utils": "^0.0.30"
       },
       "dependencies": {
         "iced-error": {
@@ -64,7 +64,7 @@
       "integrity": "sha1-HXH/k8kElyimRoOFqpvIkf10xY8=",
       "dev": true,
       "requires": {
-        "iced-runtime": "1.0.3"
+        "iced-runtime": ">=0.0.1"
       }
     },
     "iced-error": {
@@ -77,7 +77,7 @@
       "resolved": "https://registry.npmjs.org/iced-lock/-/iced-lock-1.1.0.tgz",
       "integrity": "sha1-YRbvHKs6zW5rEIk7snumIv0/3nI=",
       "requires": {
-        "iced-runtime": "1.0.3"
+        "iced-runtime": "^1.0.0"
       }
     },
     "iced-runtime": {
@@ -91,10 +91,10 @@
       "integrity": "sha1-YecUn0Q/5ch/9ALLwiFKQtVYrys=",
       "dev": true,
       "requires": {
-        "colors": "1.3.0",
-        "deep-equal": "1.0.1",
-        "iced-runtime": "1.0.3",
-        "minimist": "1.2.0"
+        "colors": ">=0.6.2",
+        "deep-equal": ">=0.2.1",
+        "iced-runtime": ">=0.0.1",
+        "minimist": ">=0.0.8"
       }
     },
     "kbpgp": {
@@ -102,19 +102,19 @@
       "resolved": "https://registry.npmjs.org/kbpgp/-/kbpgp-2.0.77.tgz",
       "integrity": "sha1-bp0vV5hb6VlsXqbJ5aODM/MasZk=",
       "requires": {
-        "bn": "1.0.1",
-        "bzip-deflate": "1.0.0",
-        "deep-equal": "1.0.1",
-        "iced-error": "0.0.12",
-        "iced-lock": "1.1.0",
-        "iced-runtime": "1.0.3",
-        "keybase-ecurve": "1.0.0",
-        "keybase-nacl": "1.0.10",
-        "minimist": "1.2.0",
-        "pgp-utils": "0.0.34",
-        "purepack": "1.0.4",
-        "triplesec": "3.0.26",
-        "tweetnacl": "0.13.3"
+        "bn": "^1.0.0",
+        "bzip-deflate": "^1.0.0",
+        "deep-equal": ">=0.2.1",
+        "iced-error": ">=0.0.10",
+        "iced-lock": "^1.0.2",
+        "iced-runtime": "^1.0.3",
+        "keybase-ecurve": "^1.0.0",
+        "keybase-nacl": "^1.0.0",
+        "minimist": "^1.2.0",
+        "pgp-utils": ">=0.0.34",
+        "purepack": ">=1.0.4",
+        "triplesec": ">=3.0.19",
+        "tweetnacl": "^0.13.1"
       }
     },
     "keybase-ecurve": {
@@ -122,7 +122,7 @@
       "resolved": "https://registry.npmjs.org/keybase-ecurve/-/keybase-ecurve-1.0.0.tgz",
       "integrity": "sha1-xrxyrdpGA/0xhP7n6ZaU7Y/WmtI=",
       "requires": {
-        "bn": "1.0.1"
+        "bn": "^1.0.0"
       }
     },
     "keybase-nacl": {
@@ -130,9 +130,9 @@
       "resolved": "https://registry.npmjs.org/keybase-nacl/-/keybase-nacl-1.0.10.tgz",
       "integrity": "sha1-OGWDHpSBUWSI33y9mJRn6VDYeos=",
       "requires": {
-        "iced-runtime": "1.0.3",
-        "tweetnacl": "0.13.3",
-        "uint64be": "1.0.1"
+        "iced-runtime": "^1.0.2",
+        "tweetnacl": "^0.13.1",
+        "uint64be": "^1.0.1"
       }
     },
     "minimist": {
@@ -145,7 +145,7 @@
       "resolved": "https://registry.npmjs.org/more-entropy/-/more-entropy-0.0.7.tgz",
       "integrity": "sha1-Z7/G96hvJvvDeqyD/UbYjGHRCbU=",
       "requires": {
-        "iced-runtime": "1.0.3"
+        "iced-runtime": ">=0.0.1"
       }
     },
     "pgp-utils": {
@@ -153,8 +153,8 @@
       "resolved": "https://registry.npmjs.org/pgp-utils/-/pgp-utils-0.0.34.tgz",
       "integrity": "sha1-2E9J98GTteC5QV9cxcKmle15DCM=",
       "requires": {
-        "iced-error": "0.0.12",
-        "iced-runtime": "1.0.3"
+        "iced-error": ">=0.0.8",
+        "iced-runtime": ">=0.0.1"
       }
     },
     "progress": {
@@ -172,11 +172,11 @@
       "resolved": "https://registry.npmjs.org/triplesec/-/triplesec-3.0.26.tgz",
       "integrity": "sha1-3/K7R1ikIzcuc5o5fYmR8Fl9CsE=",
       "requires": {
-        "iced-error": "0.0.12",
-        "iced-lock": "1.1.0",
-        "iced-runtime": "1.0.3",
-        "more-entropy": "0.0.7",
-        "progress": "1.1.8"
+        "iced-error": ">=0.0.9",
+        "iced-lock": "^1.0.1",
+        "iced-runtime": "^1.0.2",
+        "more-entropy": ">=0.0.7",
+        "progress": "~1.1.2"
       }
     },
     "tweetnacl": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "keybase-proofs",
-  "version": "2.1.46",
+  "version": "2.1.47",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keybase-proofs",
-  "version": "2.1.46",
+  "version": "2.1.47",
   "description": "Publicly-verifiable proofs of identity",
   "main": "lib/main.js",
   "scripts": {

--- a/src/base.iced
+++ b/src/base.iced
@@ -602,7 +602,7 @@ class Base
   #------
 
   hex_to_buf : ({hex_str, n}, cb) ->
-    buf = null
+    err = buf = null
 
     if not hex_str?
       return cb null, buf

--- a/src/base.iced
+++ b/src/base.iced
@@ -155,8 +155,8 @@ class Verifier
       new Error "wrong ignore_if_unsupported value: #{errsan a} != #{errsan b}"
     else if (a = outer.get_hprev_info()?.seqno) isnt (b = (inner_obj.hprev_info?.seqno))
       new Error "wrong hprev seqno: #{errsan a} != #{errsan b}"
-    else if (a = outer.get_hprev_info()?.hash) isnt (b = (inner_obj.hprev_info?.hash))
-      new Error "wrong hprev hash value: #{errsan a} != #{errsan b}"
+    else if not compare_hash_buf_to_str (a = outer.get_hprev_info()?.hash), (b = (inner_obj.hprev_info?.hash))
+      new Error "wrong hprev hash value: #{a?.toString('hex')} != #{errsan b}"
     else
       null
     cb err, outer
@@ -600,30 +600,52 @@ class Base
     else @generate cb
 
   #------
+  
+  hex_to_buf : ({hex_str, n}, cb) ->
+    if not hex_str?
+      return cb null, null
+
+    # expect a SHA256 hash by default
+    n or= 32
+      
+    try
+      buf = new Buffer(hex_str, 'hex')
+    catch e
+      err = new Error "failed to read #{errsan hex_str} as a hex string"
+    if not err? and buf.length isnt n
+      err = new Error "bad hash length: #{buf.length}"
+
+    cb null, buf
+
+  #------
 
   generate_outer : ({inner}, cb) ->
     ret = prev_buf = err = unpacked = null
 
-    if (p = inner.obj.prev)?
-      try
-        prev_buf = new Buffer(p, 'hex')
-      catch e
-        err = new Error "failed to read #{errsan p} as a hex string"
-      if not err? and prev_buf.length isnt 32 # expect a SHA256 hash
-        err = new Error "bad hash length: #{prev_buf.length}"
+    await @hex_to_buf { hex_str: inner?.obj?.prev }, defer err, prev_buf
+    return cb err, ret, unpacked if err?
+    await @hex_to_buf { hex_str: inner.obj.hprev_info?.hash }, defer err, hprev_hash_buf
+    return cb err, ret, unpacked if err?
 
-    unless err?
-      unpacked = new OuterLink {
-        version : constants.versions.sig_v2
-        type : @_type_v2()
-        seqno : (inner.obj.seqno or 0)
-        prev : prev_buf
-        hash : hash_sig(new Buffer inner.str, 'utf8')
-        seq_type : if (x = inner.obj.seq_type_for_testing)? then x else (inner.obj.seq_type or constants.seq_types.SEMIPRIVATE)
-        ignore_if_unsupported : if (x = inner.obj.ignore_if_unsupported_for_testing)? then x else !!(inner.obj.ignore_if_unsupported or false)
-        hprev_info : inner.obj.hprev_info or null
+    if inner.obj.hprev_info?
+      hprev_info = {
+        seqno: inner.obj.hprev_info.seqno,
+        hash: hprev_hash_buf
       }
-      ret = unpacked.pack()
+    else
+      hprev_info = null
+
+    unpacked = new OuterLink {
+      version : constants.versions.sig_v2
+      type : @_type_v2()
+      seqno : (inner.obj.seqno or 0)
+      prev : prev_buf
+      hash : hash_sig(new Buffer inner.str, 'utf8')
+      seq_type : if (x = inner.obj.seq_type_for_testing)? then x else (inner.obj.seq_type or constants.seq_types.SEMIPRIVATE)
+      ignore_if_unsupported : if (x = inner.obj.ignore_if_unsupported_for_testing)? then x else !!(inner.obj.ignore_if_unsupported or false)
+      hprev_info : hprev_info
+    }
+    ret = unpacked.pack()
 
     cb err, ret, unpacked
 


### PR DESCRIPTION
Prior to this commit, hprev hashes were being treated as strings instead of buffers.