### PR TITLE
Add eldest_kid checking in proof engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## 2.1.48 (2018-09-05)
+## 2.1.50 (2018-09-06)
+
+- Added `eldest_kid` checking during verification.
+
+## 2.1.49 (2018-09-05)
 
 - Add support for `high_skip` fields to point to the last high link.
 

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -47,6 +47,10 @@
       return false;
     };
 
+    Auth.prototype._v_require_eldest_kid = function() {
+      return false;
+    };
+
     return Auth;
 
   })(Base);

--- a/lib/base.js
+++ b/lib/base.js
@@ -684,6 +684,10 @@
       return true;
     };
 
+    Base.prototype._v_require_eldest_kid = function() {
+      return true;
+    };
+
     Base.prototype.full_pgp_hash = function(opts, cb) {
       var esc, ___iced_passed_deferral, __iced_deferrals, __iced_k;
       __iced_k = __iced_k_noop;
@@ -706,7 +710,7 @@
                       return __slot_1._full_pgp_hash = arguments[0];
                     };
                   })(_this),
-                  lineno: 338
+                  lineno: 342
                 })));
               }
               __iced_deferrals._fulfill();
@@ -745,7 +749,7 @@
                 return full_hash = arguments[1];
               };
             })(),
-            lineno: 347
+            lineno: 351
           }));
           __iced_deferrals._fulfill();
         });
@@ -791,7 +795,7 @@
                     return hash_real = arguments[1];
                   };
                 })(),
-                lineno: 365
+                lineno: 369
               }));
               __iced_deferrals._fulfill();
             })(function() {
@@ -807,7 +811,7 @@
     };
 
     Base.prototype._v_check_user = function(_arg) {
-      var a, b, e, has_user_id, json, v, x, _ref10, _ref11, _ref12, _ref2, _ref3, _ref4, _ref5, _ref6, _ref7, _ref8, _ref9;
+      var a, b, e, ek, has_user_id, json, v, x, _ref10, _ref11, _ref12, _ref13, _ref14, _ref2, _ref3, _ref4, _ref5, _ref6, _ref7, _ref8, _ref9;
       json = _arg.json;
       has_user_id = false;
       if (json != null ? (_ref2 = json.body) != null ? (_ref3 = _ref2.key) != null ? _ref3.username : void 0 : void 0 : void 0) {
@@ -817,7 +821,7 @@
           has_user_id = true;
         }
       } else if (this._v_require_username()) {
-        return new Error("no username given, but was was required");
+        return new Error("no username given, but was required");
       }
       if (json != null ? (_ref6 = json.body) != null ? (_ref7 = _ref6.key) != null ? _ref7.uid : void 0 : void 0 : void 0) {
         if ((a = json != null ? (_ref8 = json.body) != null ? (_ref9 = _ref8.key) != null ? _ref9.uid : void 0 : void 0 : void 0) !== (b = this.user.local.uid)) {
@@ -826,7 +830,7 @@
           has_user_id = true;
         }
       } else if (this._v_require_uid()) {
-        return new Error("no uid given, but was was required");
+        return new Error("no uid given, but was required");
       }
       if (((v = this.user.local.emails) != null) && ((e = json != null ? (_ref10 = json.body) != null ? (_ref11 = _ref10.key) != null ? _ref11.email : void 0 : void 0 : void 0) != null)) {
         if (_ref12 = e.toLowerCase(), __indexOf.call((function() {
@@ -847,6 +851,16 @@
       }
       if (!has_user_id) {
         return new Error("no UID or username given for signature");
+      }
+      if ((ek = json != null ? (_ref13 = json.body) != null ? (_ref14 = _ref13.key) != null ? _ref14.eldest_kid : void 0 : void 0 : void 0)) {
+        if (!(this.eldest_kid != null)) {
+          return new Error("Local user does not have eldest_kid when checking sig type: " + (this._type()));
+        }
+        if (ek !== this.eldest_kid) {
+          return new Error("Wrong eldest_kid: got '" + (errsan(ek)) + "' but wanted '" + (errsan(this.eldest_kid)) + "'");
+        }
+      } else if (this._v_require_eldest_kid()) {
+        return new Error("no eldest_kid given, but was required");
       }
       return null;
     };
@@ -884,7 +898,7 @@
                     return err = arguments[0];
                   };
                 })(),
-                lineno: 449
+                lineno: 463
               }));
               __iced_deferrals._fulfill();
             })(__iced_k);
@@ -1024,7 +1038,7 @@
                 return err = arguments[0];
               };
             })(),
-            lineno: 555
+            lineno: 569
           }));
           __iced_deferrals._fulfill();
         });
@@ -1056,7 +1070,7 @@
             funcname: "Base.generate"
           });
           _this._v_generate(opts, esc(__iced_deferrals.defer({
-            lineno: 569
+            lineno: 583
           })));
           __iced_deferrals._fulfill();
         });
@@ -1075,7 +1089,7 @@
                   return json_obj = arguments[1];
                 };
               })(),
-              lineno: 570
+              lineno: 584
             })));
             __iced_deferrals._fulfill();
           })(function() {
@@ -1097,7 +1111,7 @@
                     return armored = arguments[0].armored;
                   };
                 })(),
-                lineno: 572
+                lineno: 586
               })));
               __iced_deferrals._fulfill();
             })(function() {
@@ -1137,7 +1151,7 @@
             funcname: "Base.generate_v2"
           });
           _this._v_generate(opts, esc(__iced_deferrals.defer({
-            lineno: 586
+            lineno: 600
           })));
           __iced_deferrals._fulfill();
         });
@@ -1156,7 +1170,7 @@
                   return o = arguments[1];
                 };
               })(),
-              lineno: 587
+              lineno: 601
             })));
             __iced_deferrals._fulfill();
           })(function() {
@@ -1178,7 +1192,7 @@
                     return outer = arguments[0];
                   };
                 })(),
-                lineno: 589
+                lineno: 603
               })));
               __iced_deferrals._fulfill();
             })(function() {
@@ -1196,7 +1210,7 @@
                       return armored = arguments[0].armored;
                     };
                   })(),
-                  lineno: 590
+                  lineno: 604
                 })));
                 __iced_deferrals._fulfill();
               })(function() {
@@ -1272,7 +1286,7 @@
                 return prev_buf = arguments[0];
               };
             })(),
-            lineno: 625
+            lineno: 639
           })));
           __iced_deferrals._fulfill();
         });
@@ -1293,7 +1307,7 @@
                   return high_skip_hash_buf = arguments[0];
                 };
               })(),
-              lineno: 626
+              lineno: 640
             })));
             __iced_deferrals._fulfill();
           })(function() {
@@ -1343,7 +1357,7 @@
                 return json_str = arguments[2];
               };
             })(),
-            lineno: 662
+            lineno: 676
           }));
           __iced_deferrals._fulfill();
         });
@@ -1389,7 +1403,7 @@
                 return json_str = arguments[3];
               };
             })(),
-            lineno: 683
+            lineno: 697
           }));
           __iced_deferrals._fulfill();
         });
@@ -1504,7 +1518,7 @@
                 return arr = arguments[0];
               };
             })(),
-            lineno: 758
+            lineno: 772
           })));
           __iced_deferrals._fulfill();
         });

--- a/lib/eldest.js
+++ b/lib/eldest.js
@@ -42,6 +42,10 @@
       }
     };
 
+    Eldest.prototype._v_require_eldest_kid = function() {
+      return false;
+    };
+
     return Eldest;
 
   })(Base);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keybase-proofs",
-  "version": "2.1.49",
+  "version": "2.1.50",
   "description": "Publicly-verifiable proofs of identity",
   "main": "lib/main.js",
   "scripts": {

--- a/src/auth.iced
+++ b/src/auth.iced
@@ -26,4 +26,8 @@ exports.Auth = class Auth extends Base
   _v_require_username : () -> false
   _v_require_uid      : () -> false
 
+  # eldest_kid is not required. This type of proof should never appear
+  # in sigchain.
+  _v_require_eldest_kid : () -> false
+
 #==========================================================================

--- a/src/eldest.iced
+++ b/src/eldest.iced
@@ -21,4 +21,9 @@ exports.Eldest = class Eldest extends Base
   _v_customize_json : (ret) ->
     ret.body.device = @device if @device?
 
+  # Eldest proofs do not require "eldest_kid" field right now.
+  # TODO: In the future, we want to enforce Eldest proofs to contain
+  # "eldest_kid" that's equal to "kid" being posted.
+  _v_require_eldest_kid : () -> false
+
 #==========================================================================

--- a/test/files/team.iced
+++ b/test/files/team.iced
@@ -42,6 +42,7 @@ exports.test_key_section_bad_and_good = (T,cb) ->
   arg.kms = {}
   await EncKeyManager.generate {}, esc defer arg.kms.encryption
   await KeyManager.generate {}, esc defer arg.kms.signing
+  arg.eldest_kid = arg.kms.signing.get_ekid().toString('hex')
 
   verify_from_arg = ({arg}, cb) ->
     obj = new team.RotateKey arg
@@ -81,6 +82,7 @@ round_trip_with_corrupted_reverse_sig = ({T, corrupt}, cb) ->
   await EncKeyManager.generate {}, esc defer arg.kms.encryption
   await KeyManager.generate {}, esc defer arg.kms.signing
   arg.kms.generation = 10
+  arg.eldest_kid = arg.kms.signing.get_ekid().toString('hex')
   obj = new team.RotateKey arg
 
   obj._v_generate = (opts, cb) ->

--- a/test/files/util.iced
+++ b/test/files/util.iced
@@ -18,3 +18,4 @@ exports.new_sig_arg = new_sig_arg = ({km}) ->
     seqno : 0
     seq_type : constants.seq_types.PUBLIC
     prev : null
+    eldest_kid : km.get_ekid().toString('hex')

--- a/test/files/v2.iced
+++ b/test/files/v2.iced
@@ -34,6 +34,7 @@ class User
     host : 'keybase.io'
     sig_eng : @km.make_sig_eng()
     seq_type : seq_type
+    eldest_kid : @km.get_ekid().toString('hex')
   }
 
 

--- a/test/files/verify.iced
+++ b/test/files/verify.iced
@@ -1,0 +1,90 @@
+{make_esc} = require 'iced-error'
+{alloc,Sibkey,Auth} = require '../../'
+{EncKeyManager,KeyManager} = require('kbpgp').kb
+{new_sig_arg} = require './util'
+
+test_klass = ({ T, klass, arg, verify_arg, v2, errfunc }, cb) ->
+  esc = make_esc cb, 'test_klass'
+  obj = new klass arg
+  if v2
+    await obj.generate_v2 esc defer out
+  else
+    await obj.generate esc defer out
+
+  typ = out.inner.obj.body.type
+  obj2 = alloc typ, verify_arg
+  arg = { armored : out.armored, skip_ids : true, make_ids : true }
+  if v2
+    arg.inner = out.inner.str
+  await obj2.verify_all_versions arg, defer err
+  if errfunc
+    cb if errfunc(err) then null else new Error("Unexpected verify outcome: #{err?.toString()}")
+  else
+    cb err
+
+test_klass_both_v = (arg, cb) ->
+  esc = make_esc cb, 'test_klass_both_v'
+  await test_klass Object.assign({}, arg, { v2 : false }), esc defer()
+  await test_klass Object.assign({}, arg, { v2 : true }), esc defer()
+  cb null
+
+state = {}
+
+exports.init = (T, cb) ->
+  esc = make_esc cb, 'init'
+  await KeyManager.generate {}, esc defer state.elder
+  await KeyManager.generate {}, esc defer state.sib
+  state.arg = new_sig_arg { km : state.elder }
+  state.arg.sibkm = state.sib
+  cb null
+
+exports.test_happy_path = (T, cb) ->
+  esc = make_esc cb, 'test_happy_path'
+  arg = verify_arg = state.arg
+  await test_klass_both_v { T, klass : Sibkey, arg, verify_arg }, esc defer()
+  cb null
+
+exports.test_no_eldest_kid_in_sig = (T, cb) ->
+  esc = make_esc cb, 'test_no_eldest_kid_in_sig'
+  arg = Object.assign {}, state.arg
+  delete arg.eldest_kid
+  verify_arg = state.arg
+  errfunc = (err) -> err?.toString().indexOf("no eldest_kid given") isnt -1
+  await test_klass_both_v { T, klass : Sibkey, arg, verify_arg, errfunc }, esc defer()
+  cb null
+
+exports.test_wrong_eldest_kid = (T, cb) ->
+  esc = make_esc cb, 'test_no_eldest_kid_during_verify'
+  arg = state.arg
+  verify_arg = Object.assign {}, state.arg
+  verify_arg.eldest_kid = Buffer.from(verify_arg.eldest_kid, 'hex').reverse().toString('hex')
+  errfunc = (err) -> err?.toString().indexOf("Wrong eldest_kid") isnt -1
+  await test_klass_both_v { T, klass : Sibkey, arg, verify_arg, errfunc }, esc defer()
+  cb null
+
+exports.test_no_eldest_kid_during_verify = (T, cb) ->
+  esc = make_esc cb, 'test_no_eldest_kid_during_verify'
+  arg = state.arg
+  verify_arg = Object.assign {}, state.arg
+  delete verify_arg.eldest_kid
+  errfunc = (err) -> err?.toString().indexOf("Local user does not have eldest_kid") isnt -1
+  await test_klass_both_v { T, klass : Sibkey, arg, verify_arg, errfunc }, esc defer()
+  cb null
+
+exports.test_sigs_without_eldest = (T, cb) ->
+  esc = make_esc cb, 'test_sigs_without_eldest'
+
+  arg = new_sig_arg { km : state.elder }
+  verify_arg = Object.assign {}, arg
+  # Do not pass eldest_kid during creation, but assume counter-party
+  # knows and passes eldest_kid during verification. This should not
+  # be an error.
+  delete arg.eldest_kid
+  await test_klass { T, klass : Auth, arg, verify_arg, v2 : false }, esc defer()
+
+  # Test that it still succeeds where both signer and verifiers don't
+  # pass eldest_kid.
+  delete verify_arg.eldest_kid
+  await test_klass { T, klass : Auth, arg, verify_arg, v2 : false }, esc defer()
+
+  cb null


### PR DESCRIPTION
This PR adds `eldest_kid` checking during proof verification. It uses `@eldest_kid` variable that's set in `Base` constructor. This variable is already used to embed `eldest_kid` in a sig, so using it for checking seems natural - especially in tests, where it sometimes calls generation and verification functions with same set of arguments.

`eldest_kid` checks right now are basically required, unless `_v_require_eldest_kid` returns `false` (which it does for Auth and Eldest sig types). This has an advantage of catching all the places where we do not pass expected eldest_kid properly, but on the other hand if we want to use this to verify old signatures, it might fail since we were not strict about eldest_kid before. Also there is no way currently to bypass this check. cc @mlsteele on this particular issue.

Also what about `UpdatePassphraseHash` and `UpdateSettings` signatures? They are not appended to sigchains either.
