### PR TITLE
update constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 2.1.53 (2018-09-24)
+
+- Change constant
+
+## 2.1.52 (2018-09-14)
+
+- Bug fixes
+
 ## 2.1.51 (2018-09-12)
 
 - Add `GenericSocialBinding` proof type, where `service_name` is not predefined.

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -94,9 +94,10 @@
       hackernews: 6,
       bitbucket: 7,
       facebook: 8,
+      generic_social: 9,
       generic_web_site: 1000,
       dns: 1001,
-      generic_social: 1002
+      pgp: 1002
     },
     expire_in: 60 * 60 * 24 * 365 * 5,
     http_timeout: 15 * 1000,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "keybase-proofs",
-  "version": "2.1.47",
+  "version": "2.1.53",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keybase-proofs",
-  "version": "2.1.52",
+  "version": "2.1.53",
   "description": "Publicly-verifiable proofs of identity",
   "main": "lib/main.js",
   "scripts": {

--- a/src/constants.iced
+++ b/src/constants.iced
@@ -85,9 +85,10 @@ exports.constants = constants =
     hackernews : 6
     bitbucket : 7
     facebook : 8
+    generic_social : 9
     generic_web_site : 1000
     dns              : 1001
-    generic_social   : 1002
+    pgp              : 1002
   expire_in : 60*60*24*365*5 # 5 years....
   http_timeout : 15*1000 # give up after 15 seconds....
   short_id_bytes : 27


### PR DESCRIPTION
I believe 1002 is already taken by "PGP". I don't know what PGP is and there aren't any on prod. But better safe than sorry. Let's move generic social to 9.
https://github.com/keybase/client/pull/13846/files#diff-ef8fd59916536fb8e588f2c9bc209c4cR84