### PR TITLE
Fix exception when calling resolveTxt with invalid unicode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.3.27 (2024-07-18)
+
+- Fix error handling when an invalid unicode domain is passed to DnsScraper.
+
 ## 2.3.26 (2024-06-17)
 
 - Use oauth API for reddit scraping.

--- a/lib/scrapers/dns.js
+++ b/lib/scrapers/dns.js
@@ -151,7 +151,7 @@
                   (function(__iced_k) {
                     __iced_deferrals = new iced.Deferrals(__iced_k, {
                       parent: ___iced_passed_deferral,
-                      filename: "/Users/max/src/keybase/proofs/src/scrapers/dns.iced",
+                      filename: "/Users/michal/SourceCode/keybase/go/src/github.com/keybase/server_test_progs/proofs/src/scrapers/dns.iced",
                       funcname: "DnsScraper.check_status"
                     });
                     _this._check_status({
@@ -191,28 +191,40 @@ _break()
       })(this));
     };
 
+    DnsScraper.prototype._resolve_txt = function(domain, cb) {
+      var dnslib, err;
+      dnslib = this.libs.dns || dns;
+      try {
+        return dnslib.resolveTxt(domain, function(err, records) {
+          return cb(err, records);
+        });
+      } catch (_error) {
+        err = _error;
+        return cb(err);
+      }
+    };
+
     DnsScraper.prototype._check_status = function(_arg, cb) {
-      var dnslib, domain, err, proof_text_check, rc, records, ___iced_passed_deferral, __iced_deferrals, __iced_k;
+      var domain, err, proof_text_check, rc, records, ___iced_passed_deferral, __iced_deferrals, __iced_k;
       __iced_k = __iced_k_noop;
       ___iced_passed_deferral = iced.findDeferral(arguments);
       domain = _arg.domain, proof_text_check = _arg.proof_text_check;
       this.log("+ DNS check for " + domain);
-      dnslib = this.libs.dns || dns;
       (function(_this) {
         return (function(__iced_k) {
           __iced_deferrals = new iced.Deferrals(__iced_k, {
             parent: ___iced_passed_deferral,
-            filename: "/Users/max/src/keybase/proofs/src/scrapers/dns.iced",
+            filename: "/Users/michal/SourceCode/keybase/go/src/github.com/keybase/server_test_progs/proofs/src/scrapers/dns.iced",
             funcname: "DnsScraper._check_status"
           });
-          dnslib.resolveTxt(domain, __iced_deferrals.defer({
+          _this._resolve_txt(domain, __iced_deferrals.defer({
             assign_fn: (function() {
               return function() {
                 err = arguments[0];
                 return records = arguments[1];
               };
             })(),
-            lineno: 105
+            lineno: 115
           }));
           __iced_deferrals._fulfill();
         });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keybase-proofs",
-  "version": "2.3.26",
+  "version": "2.3.27",
   "description": "Publicly-verifiable proofs of identity",
   "main": "lib/main.js",
   "scripts": {

--- a/src/scrapers/dns.iced
+++ b/src/scrapers/dns.iced
@@ -97,13 +97,23 @@ exports.DnsScraper = class DnsScraper extends BaseScraper
 
   # ---------------------------------------------------------------------------
 
+  _resolve_txt : (domain, cb) ->
+    # We can use a DNS library passed in (in the case of native-dns running on
+    # the server)
+    dnslib = @libs.dns or dns
+    try
+      dnslib.resolveTxt domain, (err, records) ->
+        cb err, records
+    catch err
+      cb err
+
+  # ---------------------------------------------------------------------------
+
   # calls back with a v_code or null if it was ok
   _check_status: ({domain, proof_text_check}, cb) ->
     @log "+ DNS check for #{domain}"
 
-    # We can use a DNS library passed in (in the case of native-dns running on the server)
-    dnslib = @libs.dns or dns
-    await dnslib.resolveTxt domain, defer err, records
+    await @_resolve_txt domain, defer err, records
     rc = if err?
       @log "| DNS error: #{err}"
       v_codes.DNS_ERROR


### PR DESCRIPTION
Sometimes resolveTxt throws when called with invalid unicode.

I couldn't repro on my system, neither with nodejs `dns` package, nor with `native-dns` that's used by Keybase server.

Some hints that other people have also been hitting this in the past: https://github.com/nodejs/node/issues/39139

The solution is to wrap resolveTxt call in try/catch, and report like any normal error.