### PR TITLE
TwitterScraper: better return code when empty resultset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.3.29 (2024-07-22)
+
+- Fix Twitter scraper to handle empty result list case.
+
 ## 2.3.28 (2024-07-19)
 
 - Use version 2 API for X (formerly known as Twitter) hunting.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keybase-proofs",
-  "version": "2.3.28",
+  "version": "2.3.29",
   "description": "Publicly-verifiable proofs of identity",
   "main": "lib/main.js",
   "scripts": {

--- a/src/scrapers/twitter.iced
+++ b/src/scrapers/twitter.iced
@@ -75,7 +75,13 @@ exports.TwitterScraper = class TwitterScraper extends BaseScraper
     @log "| search index #{u} -> #{rc}"
     if rc isnt v_codes.OK then #noop
     else if not json? or (json.length is 0) then rc = v_codes.EMPTY_JSON
-    else if not json.data? then rc = v_codes.INVALID_JSON
+    else if not json.data?
+      if json.meta?.result_count is 0
+        # No results.
+        rc = v_codes.NOT_FOUND
+      else
+        # Unknown JSON structure.
+        rc = v_codes.INVALID_JSON
     else
       rc = v_codes.NOT_FOUND
       for {text, id},i in json.data


### PR DESCRIPTION
If there's no `data` field, check `meta.result_count` if it's an empty set. If so, return `NOT_FOUND` instead of `INVALID_JSON`.