### PR TITLE
Limit response size in GenericWebSiteScraper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.3.31 (2025-12-18)
+
+- Set response size limit when making a request in GenericWebSiteScraper.
+
 ## 2.3.30 (2025-02-28)
 
 - Fix BaseScraper not properly handling promise rejections when fetching text

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -132,6 +132,7 @@
     },
     expire_in: 60 * 60 * 24 * 365 * 5,
     http_timeout: 15 * 1000,
+    generic_website_max_size: 128000,
     short_id_bytes: 27,
     shortest_pgp_signature: 100,
     critical_clock_skew_secs: 65 * 60,

--- a/lib/scrapers/generic_web_site.js
+++ b/lib/scrapers/generic_web_site.js
@@ -58,19 +58,21 @@
     };
 
     GenericWebSiteScraper.prototype._check_url = function(_arg, cb) {
-      var err, proof_text_check, raw, rc, url, ___iced_passed_deferral, __iced_deferrals, __iced_k;
+      var err, proof_text_check, raw, rc, size, url, ___iced_passed_deferral, __iced_deferrals, __iced_k;
       __iced_k = __iced_k_noop;
       ___iced_passed_deferral = iced.findDeferral(arguments);
       url = _arg.url, proof_text_check = _arg.proof_text_check;
+      size = constants.generic_website_max_size;
       (function(_this) {
         return (function(__iced_k) {
           __iced_deferrals = new iced.Deferrals(__iced_k, {
             parent: ___iced_passed_deferral,
-            filename: "/Users/max/src/keybase/proofs/src/scrapers/generic_web_site.iced",
+            filename: "/Users/michal/SourceCode/keybase/go/src/github.com/keybase/proofs/src/scrapers/generic_web_site.iced",
             funcname: "GenericWebSiteScraper._check_url"
           });
           _this._get_url_body({
-            url: url
+            url: url,
+            size: size
           }, __iced_deferrals.defer({
             assign_fn: (function() {
               return function() {
@@ -79,7 +81,7 @@
                 return raw = arguments[2];
               };
             })(),
-            lineno: 48
+            lineno: 50
           }));
           __iced_deferrals._fulfill();
         });
@@ -132,7 +134,7 @@
                   (function(__iced_k) {
                     __iced_deferrals = new iced.Deferrals(__iced_k, {
                       parent: ___iced_passed_deferral,
-                      filename: "/Users/max/src/keybase/proofs/src/scrapers/generic_web_site.iced",
+                      filename: "/Users/michal/SourceCode/keybase/go/src/github.com/keybase/proofs/src/scrapers/generic_web_site.iced",
                       funcname: "GenericWebSiteScraper.hunt2"
                     });
                     _this._check_url({
@@ -145,7 +147,7 @@
                           return rc = arguments[1];
                         };
                       })(),
-                      lineno: 66
+                      lineno: 68
                     }));
                     __iced_deferrals._fulfill();
                   })(function() {
@@ -215,7 +217,7 @@ _break()
         return (function(__iced_k) {
           __iced_deferrals = new iced.Deferrals(__iced_k, {
             parent: ___iced_passed_deferral,
-            filename: "/Users/max/src/keybase/proofs/src/scrapers/generic_web_site.iced",
+            filename: "/Users/michal/SourceCode/keybase/go/src/github.com/keybase/proofs/src/scrapers/generic_web_site.iced",
             funcname: "GenericWebSiteScraper.check_status"
           });
           _this._check_url({
@@ -228,7 +230,7 @@ _break()
                 return rc = arguments[1];
               };
             })(),
-            lineno: 95
+            lineno: 97
           }));
           __iced_deferrals._fulfill();
         });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keybase-proofs",
-  "version": "2.3.30",
+  "version": "2.3.31",
   "description": "Publicly-verifiable proofs of identity",
   "main": "lib/main.js",
   "scripts": {

--- a/src/constants.iced
+++ b/src/constants.iced
@@ -115,8 +115,10 @@ exports.constants = constants =
     generic_web_site : 1000
     dns              : 1001
     pgp              : 1002
+
   expire_in : 60*60*24*365*5 # 5 years....
   http_timeout : 15*1000 # give up after 15 seconds....
+  generic_website_max_size : 128000 # do not download more than 128KB from generic websites
   short_id_bytes : 27
   shortest_pgp_signature : 100 # can't have a PGP signature shorter than this...
   critical_clock_skew_secs : 65*60 # if you clock is ~1 hour off, we won't accept the sig

--- a/src/scrapers/generic_web_site.iced
+++ b/src/scrapers/generic_web_site.iced
@@ -45,8 +45,10 @@ exports.GenericWebSiteScraper = class GenericWebSiteScraper extends BaseScraper
   # ---------------------------------------------------------------------------
 
   _check_url : ( { url, proof_text_check }, cb) ->
+    # limit how much data we want to receive from arbitrary websites
+    size = constants.generic_website_max_size
     # calls back with a v_code or null if it was ok
-    await @_get_url_body {url }, defer err, rc, raw
+    await @_get_url_body { url, size }, defer err, rc, raw
     rc = if rc isnt v_codes.OK                             then rc
     else if @_find_sig_in_raw(proof_text_check, raw)       then v_codes.OK
     else                                                   v_codes.NOT_FOUND


### PR DESCRIPTION
In generic web site scraper, pass `size` param to fetch library. Avoid wasting resources when an arbitrary website decides to serve us lots of data. Limit download to 128 KB.