### PR TITLE
Fix twitter search query

### DIFF
--- a/lib/scrapers/twitter.js
+++ b/lib/scrapers/twitter.js
@@ -106,7 +106,7 @@
         protocol: "https:",
         pathname: endpoint_name,
         query: {
-          query: "\"Verifying myself\" \"Keybase.io\" from:" + username
+          query: "\"Verifying myself: I am\" from:" + username
         }
       });
       (function(_this) {

--- a/src/scrapers/twitter.iced
+++ b/src/scrapers/twitter.iced
@@ -69,7 +69,7 @@ exports.TwitterScraper = class TwitterScraper extends BaseScraper
       protocol : "https:"
       pathname : endpoint_name
       query :
-        query : "\"Verifying myself\" \"Keybase.io\" from:#{username}"
+        query : "\"Verifying myself: I am\" from:#{username}"
     }
     await @_get_body_api { url : u, endpoint_name }, defer err, rc, json
     @log "| search index #{u} -> #{rc}"


### PR DESCRIPTION
Twitter search now searches through the tweets with URLs already transformed using the t.co link shortener, so searching for "Keybase.io" will not find any tweets.